### PR TITLE
Fix relative last week

### DIFF
--- a/lib/datebox/relative.rb
+++ b/lib/datebox/relative.rb
@@ -77,6 +77,7 @@ module Datebox
       def last_week(options = {})
         last_weekday = options[:last_weekday] || options['last_weekday'] || 'Sunday'
         new Proc.new { |relative_to|
+          relative_to -= 1
           end_date = (relative_to.downto relative_to - 6).to_a.find { |d| d.strftime("%A") == last_weekday }
           Period.new(end_date - 6, end_date)
         }, __method__.to_s

--- a/lib/datebox/relative.rb
+++ b/lib/datebox/relative.rb
@@ -3,7 +3,7 @@ module Datebox
 
     @period_proc = nil
     attr_reader :period_name
-    
+
     def initialize(proc, name = nil)
       @period_proc = proc
       @period_name = name
@@ -44,12 +44,12 @@ module Datebox
       def day_before
         new Proc.new {|relative_to| Period.new(relative_to - 1, relative_to - 1) }, __method__.to_s
       end
-      
+
       def day_apart(difference)
         new Proc.new {|relative_to| Period.new(relative_to + difference, relative_to + difference) }, __method__.to_s
       end
-      
-      def method_missing(m, *args, &block)  
+
+      def method_missing(m, *args, &block)
         if (m.to_s =~ /^day_ago_\d+$/) or (m.to_s =~ /^day_in_\d+$/)
           days = m.to_s.split('_').last.to_i
           if m.to_s =~ /^day_ago_\d+$/
@@ -62,8 +62,8 @@ module Datebox
         else
           super
         end
-      end  
-      
+      end
+
       def last_n_days(options = {})
         days = (options[:days] || options['days']).to_i
         inclusive = (options[:exclusive] || options['exclusive']) ? false : true # inclusive by default
@@ -110,7 +110,7 @@ module Datebox
           end
         }, __method__.to_s
       end
-      
+
       def same_week(options = {})
         last_weekday = options[:last_weekday] || options['last_weekday'] || 'Sunday'
         new Proc.new { |relative_to|
@@ -124,7 +124,7 @@ module Datebox
       end
 
       def last_month
-        new Proc.new { |relative_to| 
+        new Proc.new { |relative_to|
           previous_month_start = Date.parse("#{relative_to.prev_month.strftime('%Y-%m')}-01")
           previous_month_end = previous_month_start.next_month - 1
           Period.new(previous_month_start, previous_month_end)
@@ -139,7 +139,7 @@ module Datebox
       end
 
       def same_month
-        new Proc.new { |relative_to| 
+        new Proc.new { |relative_to|
           same_month_start = Date.parse("#{relative_to.strftime('%Y-%m')}-01")
           same_month_end = same_month_start.next_month - 1
           Period.new(same_month_start, same_month_end)
@@ -163,5 +163,5 @@ module Datebox
 
     end
   end
-  
+
 end

--- a/test/unit/test_relative.rb
+++ b/test/unit/test_relative.rb
@@ -24,6 +24,7 @@ class TestRelative < Test::Unit::TestCase
     # week
     assert_equal Datebox::Period.new('2013-07-01', '2013-07-07'), Datebox::Relative.last_week.to('2013-07-09') # tue
     assert_equal Datebox::Period.new('2013-06-30', '2013-07-06'), Datebox::Relative.last_week({:last_weekday => "Saturday"}).to('2013-07-09') #tue
+    assert_equal Datebox::Period.new('2015-10-26', '2015-11-01'), Datebox::Relative.last_week.to('2015-11-08') # sun
     assert_equal Datebox::Period.new('2013-07-01', '2013-07-05'), Datebox::Relative.last_weekdays_between("Monday", "Friday").to('2013-07-09') # tue
     assert_equal Datebox::Period.new('2013-07-08', '2013-07-09'), Datebox::Relative.last_weekdays_between("Monday", "Tuesday").to('2013-07-09') #tue
 

--- a/test/unit/test_relative.rb
+++ b/test/unit/test_relative.rb
@@ -5,7 +5,7 @@ class TestRelative < Test::Unit::TestCase
   def test_gives_back_correct_period_name_in_proc
     assert_equal :day_in_19, Datebox::Relative.day_in_19.period_name
   end
-  
+
   def test_calculates_correctly
     # day
     assert_equal [Date.parse('2013-07-07')], Datebox::Relative.same_day.to('2013-07-07').dates
@@ -52,11 +52,11 @@ class TestRelative < Test::Unit::TestCase
 
     # the one that's different
     assert_equal [Date.parse('2013-07-01'), Date.parse('2013-07-03')], Datebox::Relative.last_weeks_weekdays_as!("Monday", "Wednesday").to('2013-07-05') #fri
-   
-   
+
     assert_equal Datebox::Period.new('2015-11-02', '2015-11-08'), Datebox::Relative.same_week.to('2015-11-02') # mon
     assert_equal Datebox::Period.new('2015-11-02', '2015-11-08'), Datebox::Relative.same_week.to('2015-11-03') # tue
     assert_equal Datebox::Period.new('2015-11-02', '2015-11-08'), Datebox::Relative.same_week.to('2015-11-08') # sun
+
 
     assert_equal Datebox::Period.new('2015-11-01', '2015-11-30'), Datebox::Relative.same_month.to('2015-11-30')
   end


### PR DESCRIPTION
This change fixes the `last_week` method when the current day is a Sunday.
It was returning the current week as it should have been returning the week before.